### PR TITLE
Handle local dependencies with absolute filenames.

### DIFF
--- a/lib/Test/FailWarnings.pm
+++ b/lib/Test/FailWarnings.pm
@@ -8,6 +8,7 @@ package Test::FailWarnings;
 
 use Test::More 0.86;
 use Carp;
+use Cwd ();
 
 our $ALLOW_DEPS = 0;
 our @ALLOW_FROM = ();
@@ -30,6 +31,13 @@ sub handler {
     $msg = '' unless defined $msg;
     chomp $msg;
     my ( $package, $filename, $line ) = _find_source();
+
+		# If the filename is absolute, make it relative if the file is in the
+		# current path. This allows properly detecting "local" dependencies.
+		if ( $filename =~ /^(?:\/|[a-z]:\\)/i ) {
+			my $directory = Cwd::getcwd();
+			$filename =~ s/^\Q$directory\E[\\\/]//;
+		}
 
     # shortcut if ignoring dependencies and warning did not
     # come from something local


### PR DESCRIPTION
I noticed today in my DBIx::NinjaORM project that Test::FailWarnings with `-allow_deps => 1` was failing when running individual tests with `perl -T -I lib t/...` but passing when using `prove`.

`prove` seems to cause caller() to systematically report absolute filenames (at least on my test machine, Ubuntu / Perl 5.10). Since Test::FailWarnings checks for local dependencies using `/^(?:t|xt|lib|blib)/`, local directories with absolute paths end up incorrectly not being considered local.

Attached is a proposed patch to make the file path relative if the file path reported is below the current path, which addresses this problem. I haven't tested on Windows, but I added the corresponding patterns in the regexps as well.

Thank you for considering this pull request!
